### PR TITLE
Minor fix for packaging

### DIFF
--- a/src/PanGu/Framework/Instance.cs
+++ b/src/PanGu/Framework/Instance.cs
@@ -10,33 +10,39 @@ namespace PanGu.Framework
 {
     public class Instance
     {
-        static public object CreateInstance(string typeName) {
+        static public object CreateInstance(string typeName)
+        {
             object obj = Assembly.GetEntryAssembly().CreateInstance(typeName); ;
 
-            if (obj != null) {
+            if (obj != null)
+            {
                 return obj;
             }
 
             //TODO: 目前还不知道以下代码怎么迁移
-            //foreach (Assembly asm in AssemblyLoadContext.Default  AppDomain.CurrentDomain.GetAssemblies())
-            //{
-            //    obj = asm.CreateInstance(typeName);
+#if !NETCORE
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                obj = asm.CreateInstance(typeName);
 
-            //    if (obj != null)
-            //    {
-            //        return obj;
-            //    }
-            //}
+                if (obj != null)
+                {
+                    return obj;
+                }
+            }
+#endif
 
             return null;
 
         }
 
-        static public object CreateInstance(Type type) {
+        static public object CreateInstance(Type type)
+        {
             return type.GetTypeInfo().Assembly.CreateInstance(type.FullName);
         }
 
-        static public object CreateInstance(Type type, string assemblyFile) {
+        static public object CreateInstance(Type type, string assemblyFile)
+        {
 #if NETCORE
             var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyFile);
 #else
@@ -48,7 +54,8 @@ namespace PanGu.Framework
             return asm.CreateInstance(type.FullName);
         }
 
-        static public Type GetType(string assemblyFile, string typeName) {
+        static public Type GetType(string assemblyFile, string typeName)
+        {
 #if NETCORE
             var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyFile);
 #else

--- a/src/PanGu/project.json
+++ b/src/PanGu/project.json
@@ -1,21 +1,48 @@
 {
+  "title": "PanGu.Core",
   "version": "1.0.0-*",
-  "buildOptions": { "define": [ "NETCORE" ] },
-  "dependencies": {
+  "description": ".NET Core version of PanGu.",
+  "authors": [ "yuleyule66", "LonghronShen" ],
 
-    "System.Runtime.Loader": "4.3.0",
-    "System.Runtime.Extensions": "4.3.0",
-    "System.Runtime": "4.3.0",
-    "System.Xml.XmlSerializer": "4.3.0",
-    "System.Runtime.Serialization.Formatters": "4.3.0",
-    "System.Reflection.TypeExtensions": "4.3.0",
-    "System.Collections.NonGeneric": "4.3.0",
-    "NETStandard.Library": "1.6.0"
+  "packOptions": {
+    "summary": ".NET Core version of PanGu.",
+    "owners": [ "yuleyule66", "LonghronShen" ],
+    "requireLicenseAcceptance": false,
+    "tags": [ "PanGu", "Lucene", ".NET", "Core", "Analysis" ],
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/ouraspnet/OurAspNet.Lucene.Net.Analysis.PanGu.git"
+    }
+  },
+
+  "dependencies": {
   },
 
   "frameworks": {
     "netstandard1.6": {
-      "imports": "dnxcore50"
+      "imports": "dnxcore50",
+      "buildOptions": {
+        "define": [ "NETCORE" ]
+      },
+      "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Collections.NonGeneric": "4.3.0",
+        "System.Reflection.TypeExtensions": "4.3.0",
+        "System.Runtime": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.Loader": "4.3.0",
+        "System.Runtime.Serialization.Formatters": "4.3.0",
+        "System.Xml.XmlSerializer": "4.3.0"
+      }
+    },
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime.Serialization": "4.0.0.0",
+        "System.Xml": "4.0.0.0",
+        "System.Xml.XmlSerializer": "4.0.0.0",
+        "System.Xml.Serialization": "4.0.0.0"
+      }
     }
   }
+
 }


### PR DESCRIPTION
Thank you for your hard work! @yuleyule66 

As for that TODO, Microsoft think AppDomain should be removed because that is not needed and unsafe. So we can't scan the whole runtime environment for all types for dynamic loaded types. Given as a cloud based or mobile based application, it is rare using dynamic types. So just commenting these code is OK for most cases I think. Maybe there will be an equivalent for this in .NET Standard 2.0 soon. Add these code back then.

Also I have made an almost done migration for Lucene.Net.Analysis.PanGu on both .NET Standard 1.6 and .NET Framework 4.5.1 platforms. See [my Lucene.Net.Analysis.PanGu netcore branch](https://github.com/LonghronShen/Lucene.Net.Analysis.PanGu/tree/netcore)